### PR TITLE
Ignore duplicate chunks unless their payload clash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +636,7 @@ dependencies = [
  "base64",
  "clap",
  "image",
+ "itertools",
  "predicates",
  "qrcode",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ qrcode = "0.12"
 image = "^0.23"
 base64 = "0.13.0"
 clap = {version = "2.33.3", features = ["yaml"]}
+itertools = "^0.10"
+
 
 [dev-dependencies]
 rand = "0.8.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,7 @@ fn decode(input_path: &Path, restored_path: &Path) -> Result<(), parser::Restore
     // re-sort the chunks for out-of-order scanning
     chunks.sort_by_key(|chunk| chunk.id);
 
-    parser::check_chunk_range(&chunks)?;
+    let chunks = parser::check_chunk_range(&chunks)?;
 
     let concatenated_chunk_payloads = chunks
         .iter()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -30,6 +30,7 @@ pub struct EncodedChunk {
     pub payload: String,
 }
 
+#[allow(dead_code)] // temporary while feature being implemented
 #[derive(Debug, PartialEq, Eq)]
 /// Things that can go wrong when restoring a chunked file
 pub enum RestoreError {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -31,7 +31,6 @@ pub struct EncodedChunk {
     pub payload: String,
 }
 
-#[allow(dead_code)] // temporary while feature being implemented
 #[derive(Debug, PartialEq, Eq)]
 /// Things that can go wrong when restoring a chunked file
 pub enum RestoreError {

--- a/tests/end_to_end_test.rs
+++ b/tests/end_to_end_test.rs
@@ -285,3 +285,61 @@ fn duplicate_chunk_skips() {
     // clean up the temp folder
     temp.close().expect("Error deleting temporary folder");
 }
+
+#[test]
+// Scenario: Restoring with a corrupted duplicate chunk fails
+fn corrupt_duplicate_chunk_fails() {
+    // Given a file with a few KB of random data
+    let temp = assert_fs::TempDir::new().unwrap();
+    let input_file = temp.child("to_send.bin");
+    let output_folder = temp.child("output_qrs");
+
+    // Fill input file with random data
+    random_file_at(&input_file, 4 * 1024);
+
+    // And qrxfil ran in exfil-mode with input filename + output folder
+    run_qrxfil_assert_success(input_file.path(), output_folder.path());
+
+    let decoded_filepath = temp.child("qr_decoded.txt");
+    let files_to_decode = read_folder_sorted(output_folder.path());
+
+    // But with corrupted duplicate chunk
+    let decoded_string = fs::read_to_string(decoded_filepath.path()).unwrap();
+
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .append(true)
+        .open(decoded_filepath.path())
+        .unwrap();
+
+    if let Err(e) = writeln!(file, "{}", &decoded_string[..30]) {
+        eprintln!("Couldn't write to file: {}", e);
+    }
+
+    decode_qr_folder_to_file(files_to_decode, decoded_filepath.path());
+    // When running qrxfil in decode-mode
+    let restored_file = temp.child("restored.bin");
+
+    let mut cmd = Command::cargo_bin("qrxfil").expect("Error find qrxfil command");
+    let args = [
+        "restore",
+        decoded_filepath.path().to_str().unwrap(),
+        restored_file.path().to_str().unwrap(),
+    ];
+
+    // Then it completes sucessfully
+    cmd.args(&args)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("corrupt duplicate chunks: [1]"));
+
+    let (md5_restored, md5_reference) =
+        md5sum_two_files(restored_file.path(), input_file.path(), temp.path());
+    // And decoded file is identical to original
+    assert_eq!(
+        md5_restored, md5_reference,
+        "Restored md5sum didn't match reference file before exfil",
+    );
+    // clean up the temp folder
+    temp.close().expect("Error deleting temporary folder");
+}

--- a/tests/end_to_end_test.rs
+++ b/tests/end_to_end_test.rs
@@ -241,3 +241,47 @@ fn missing_chunk_error() {
 }
 
 // TODO trigger parser::RestoreError's other enum cases (TooManyChunks, ChunkDecodeError, TotalMismatch) as unittest
+
+#[test]
+// Scenario: Restoring with a duplicate chunk succeeds
+fn duplicate_chunk_skips() {
+    // Given a file with a few KB of random data
+    let temp = assert_fs::TempDir::new().unwrap();
+    let input_file = temp.child("to_send.bin");
+    let output_folder = temp.child("output_qrs");
+
+    // Fill input file with random data
+    random_file_at(&input_file, 4 * 1024);
+
+    // And qrxfil ran in exfil-mode with input filename + output folder
+    run_qrxfil_assert_success(input_file.path(), output_folder.path());
+
+    let decoded_filepath = temp.child("qr_decoded.txt");
+    let mut files_to_decode = read_folder_sorted(output_folder.path());
+    // But with duplicate chunk
+    files_to_decode.push(files_to_decode[0].clone());
+
+    decode_qr_folder_to_file(files_to_decode, decoded_filepath.path());
+    // When running qrxfil in decode-mode
+    let restored_file = temp.child("restored.bin");
+
+    let mut cmd = Command::cargo_bin("qrxfil").expect("Error find qrxfil command");
+    let args = [
+        "restore",
+        decoded_filepath.path().to_str().unwrap(),
+        restored_file.path().to_str().unwrap(),
+    ];
+
+    // Then it completes sucessfully
+    cmd.args(&args).assert().success();
+
+    let (md5_restored, md5_reference) =
+        md5sum_two_files(restored_file.path(), input_file.path(), temp.path());
+    // And decoded file is identical to original
+    assert_eq!(
+        md5_restored, md5_reference,
+        "Restored md5sum didn't match reference file before exfil",
+    );
+    // clean up the temp folder
+    temp.close().expect("Error deleting temporary folder");
+}


### PR DESCRIPTION
Chunks found twice (scanned twice) should get ignored, unless their payload differs, which is a clue of bad scan or wrong chunk (different file).

Fixes #17 

New end to end test for both cases (duplicate ignored OK and mismatching duplicate).

New RestoreError::MismatchingDuplicateChunk enum case for when a chunk was found multiple times with different payload.

Feature implemented by check_chunk_range(), new unit test for that too.

All tests currently RED (WIP feature). Will turn PR to "Ready" once tests are green (TDD!)

