### PR TITLE
Iterator refactor

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,7 +1,7 @@
 version = "Two"
 use_field_init_shorthand = true
-imports_granularity = "Crate"
-wrap_comments = true
+imports_granularity = "Module"
+wrap_comments = false
 use_try_shorthand = true
 format_code_in_doc_comments = true
 format_strings = true

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -8,7 +8,7 @@ binary application not a library with a contract.
 * [Unreleased]
 
 ** Added
-- Iterators to generate chunks from given strings
+- Refactored encoding to use iterators generating chunks [[https://github.com/OverkillGuy/qrxfil/pull/21][#21]]
 
 * [0.1.0] - 2021-03-27
 

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -7,6 +7,8 @@ binary application not a library with a contract.
 
 * [Unreleased]
 
+** Added
+- Iterators to generate chunks from given strings
 
 * [0.1.0] - 2021-03-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
- "yaml-rust",
 ]
 
 [[package]]
@@ -1016,9 +1015,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "yaml-rust"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,6 +641,7 @@ dependencies = [
  "rand",
  "rqrr",
  "test-case",
+ "thiserror",
 ]
 
 [[package]]
@@ -895,6 +896,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.63",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ image = "^0.23"
 base64 = "0.13.0"
 clap = "2.33.3"
 itertools = "^0.10"
-
+thiserror = "1.0.24"
 
 [dev-dependencies]
 rand = "0.8.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 qrcode = "0.12"
 image = "^0.23"
 base64 = "0.13.0"
-clap = {version = "2.33.3", features = ["yaml"]}
+clap = "2.33.3"
 itertools = "^0.10"
 
 

--- a/src/chunk_iterator.rs
+++ b/src/chunk_iterator.rs
@@ -43,6 +43,56 @@ where
     }
 }
 
+/// An iterator for generating chunk strings
+/// Taking total payload size and keeping count of chunk ID/total
+pub struct ChunkIterator<T>
+where
+    T: BufRead,
+{
+    reader: BufferedIterator<T>,
+    /// How big is the content that can be read
+    _total_size: u64,
+    /// How many chunks are there in total
+    chunk_total: u16,
+    /// Chunk counter incremented on each next()
+    current_chunk_id: u16,
+    // base64_writer: // TODO
+}
+
+impl<T> ChunkIterator<T>
+where
+    T: BufRead,
+{
+    #[allow(dead_code)] // Temporary while no consumer of this API
+    /// Get a new iterator ready to read `chunk_size` bytes from `reader`, representing
+    pub fn new(reader: BufferedIterator<T>, total_size: u64) -> Self {
+        Self {
+            reader,
+            _total_size: total_size,
+            chunk_total: 10,
+            current_chunk_id: 1,
+        }
+    }
+}
+
+impl<T> Iterator for ChunkIterator<T>
+where
+    T: BufRead,
+{
+    type Item = io::Result<String>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.reader.next() {
+            None => panic!("Empty iterator"),
+            Some(Ok(buf)) => Some(Ok(format!(
+                "{:03}OF{:03}{:?}",
+                self.current_chunk_id, self.chunk_total, buf
+            ))),
+            Some(Err(e)) => Some(Err(e)),
+        }
+    }
+}
+
 #[cfg(test)]
 mod iterator_tests {
     use super::*;
@@ -101,4 +151,66 @@ mod iterator_tests {
         let res3 = iter.next();
         assert!(res3.is_none());
     }
+}
+
+#[cfg(test)]
+mod chunk_iterator_tests {
+    use super::*;
+    use std::convert::TryInto;
+
+    #[test]
+    fn read_ok_twice_noleftover_test() {
+        // Given a 10 byte payload
+        let payload = "foobarbaz!";
+        let cursor = io::Cursor::<Vec<u8>>::new(payload.as_bytes().to_vec());
+        // And an iterator taking 5 bytes
+        let str_iter = BufferedIterator::new(cursor, 5);
+        let mut chunk_iter = ChunkIterator::new(str_iter, payload.len().try_into().unwrap());
+
+        // When I call iterator.next() three times
+        let res = match chunk_iter.next() {
+            None => panic!("iterator returned no data first time"),
+            Some(Err(e)) => panic!(e),
+            Some(Ok(buf)) => buf,
+        };
+        // Then the first two yield Some payload
+        assert_eq!(res, ["001OF010", &payload[..5]].concat());
+        // let res2 = match chunk_iter.next() {
+        //     None => panic!("iterator returned no data"),
+        //     Some(Err(e)) => panic!(e),
+        //     Some(Ok(buf)) => buf,
+        // };
+        // assert_eq!(res2, payload[5..]);
+        // // But the third returns None
+        // let res3 = chunk_iter.next();
+        // assert!(res3.is_none());
+    }
+
+    // #[test]
+    // fn read_ok_twice_leftover_test() {
+    //     // Given a 11 byte payload
+    //     let payload = b"foobarmore!";
+    //     let cursor = io::Cursor::<Vec<u8>>::new(payload.to_vec());
+    //     // And an iterator taking 6 bytes
+    //     let mut iter = ChunkIterator::new(cursor, 6);
+
+    //     // When I call iterator.next() thrice
+    //     let res = match iter.next() {
+    //         None => panic!("iterator returned no data first time"),
+    //         Some(Err(e)) => panic!(e),
+    //         Some(Ok(buf)) => buf,
+    //     };
+    //     // Then the first yields Some payload
+    //     assert_eq!(res, payload[..6]);
+    //     let res2 = match iter.next() {
+    //         None => panic!("iterator returned no data"),
+    //         Some(Err(e)) => panic!(e),
+    //         Some(Ok(buf)) => buf,
+    //     };
+    //     // And the second returns leftover payload
+    //     assert_eq!(res2, payload[6..]);
+    //     // But the third returns None
+    //     let res3 = iter.next();
+    //     assert!(res3.is_none());
+    // }
 }

--- a/src/chunk_iterator.rs
+++ b/src/chunk_iterator.rs
@@ -1,0 +1,104 @@
+use std::io;
+use std::io::{BufRead, Read};
+
+#[allow(dead_code)] // Temporary while no consumer of this API
+/// An iterator for reading `chunk_size` bytes off the given `reader`
+pub struct BufferedIterator<T>
+where
+    T: Read,
+{
+    reader: T,
+    chunk_size: u64,
+}
+
+impl<T> BufferedIterator<T>
+where
+    T: Read,
+{
+    #[allow(dead_code)] // Temporary while no consumer of this API
+    /// Get a new iterator ready to read `chunk_size` bytes from `reader`
+    pub fn new(reader: T, chunk_size: u64) -> Self {
+        Self { reader, chunk_size }
+    }
+}
+
+impl<T> Iterator for BufferedIterator<T>
+where
+    T: BufRead,
+{
+    type Item = io::Result<Vec<u8>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut buf = Vec::default();
+        match self
+            .reader
+            .by_ref()
+            .take(self.chunk_size)
+            .read_to_end(&mut buf)
+        {
+            Ok(0) => None,
+            Ok(_n) => Some(Ok(buf)),
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod iterator_tests {
+    use super::*;
+
+    #[test]
+    fn read_ok_twice_noleftover_test() {
+        // Given a 10 byte payload
+        let payload = b"foobarbaz!";
+        let cursor = io::Cursor::<Vec<u8>>::new(payload.to_vec());
+        // And an iterator taking 5 bytes
+        let mut iter = BufferedIterator::new(cursor, 5);
+
+        // When I call iterator.next() three times
+        let res = match iter.next() {
+            None => panic!("iterator returned no data first time"),
+            Some(Err(e)) => panic!(e),
+            Some(Ok(buf)) => buf,
+        };
+        // Then the first two yield Some payload
+        assert_eq!(res, payload[..5]);
+        let res2 = match iter.next() {
+            None => panic!("iterator returned no data"),
+            Some(Err(e)) => panic!(e),
+            Some(Ok(buf)) => buf,
+        };
+        assert_eq!(res2, payload[5..]);
+        // But the third returns None
+        let res3 = iter.next();
+        assert!(res3.is_none());
+    }
+
+    #[test]
+    fn read_ok_twice_leftover_test() {
+        // Given a 11 byte payload
+        let payload = b"foobarmore!";
+        let cursor = io::Cursor::<Vec<u8>>::new(payload.to_vec());
+        // And an iterator taking 6 bytes
+        let mut iter = BufferedIterator::new(cursor, 6);
+
+        // When I call iterator.next() thrice
+        let res = match iter.next() {
+            None => panic!("iterator returned no data first time"),
+            Some(Err(e)) => panic!(e),
+            Some(Ok(buf)) => buf,
+        };
+        // Then the first yields Some payload
+        assert_eq!(res, payload[..6]);
+        let res2 = match iter.next() {
+            None => panic!("iterator returned no data"),
+            Some(Err(e)) => panic!(e),
+            Some(Ok(buf)) => buf,
+        };
+        // And the second returns leftover payload
+        assert_eq!(res2, payload[6..]);
+        // But the third returns None
+        let res3 = iter.next();
+        assert!(res3.is_none());
+    }
+}

--- a/src/chunk_iterator.rs
+++ b/src/chunk_iterator.rs
@@ -3,7 +3,6 @@ use std::io::{BufRead, Read};
 
 use crate::parser::EncodedChunk;
 
-#[allow(dead_code)] // Temporary while no consumer of this API
 /// An iterator for reading `chunk_size` bytes off the given `reader`
 pub struct BufferedIterator<T>
 where
@@ -17,7 +16,6 @@ impl<T> BufferedIterator<T>
 where
     T: Read,
 {
-    #[allow(dead_code)] // Temporary while no consumer of this API
     /// Get a new iterator ready to read `chunk_size` bytes from `reader`
     pub fn new(reader: T, chunk_size: u64) -> Self {
         Self { reader, chunk_size }
@@ -53,9 +51,9 @@ where
 {
     reader: BufferedIterator<T>,
     /// How many chunks are there in total
-    chunk_total: u16,
+    pub chunk_total: u16,
     /// Chunk counter incremented on each next()
-    current_chunk_id: u16,
+    pub current_chunk_id: u16,
 }
 
 impl<T> ChunkIterator<T>

--- a/src/chunk_iterator.rs
+++ b/src/chunk_iterator.rs
@@ -116,14 +116,14 @@ mod iterator_tests {
         // When I call iterator.next() three times
         let res = match iter.next() {
             None => panic!("iterator returned no data first time"),
-            Some(Err(e)) => panic!(e),
+            Some(Err(e)) => panic!("Iteration failed on known buffer. Got {}", e),
             Some(Ok(buf)) => buf,
         };
         // Then the first two yield Some payload
         assert_eq!(res, payload[..5]);
         let res2 = match iter.next() {
             None => panic!("iterator returned no data"),
-            Some(Err(e)) => panic!(e),
+            Some(Err(e)) => panic!("Iteration failed on known buffer. Got {}", e),
             Some(Ok(buf)) => buf,
         };
         assert_eq!(res2, payload[5..]);
@@ -143,14 +143,14 @@ mod iterator_tests {
         // When I call iterator.next() thrice
         let res = match iter.next() {
             None => panic!("iterator returned no data first time"),
-            Some(Err(e)) => panic!(e),
+            Some(Err(e)) => panic!("Iteration failed on known buffer. Got {}", e),
             Some(Ok(buf)) => buf,
         };
         // Then the first yields Some payload
         assert_eq!(res, payload[..6]);
         let res2 = match iter.next() {
             None => panic!("iterator returned no data"),
-            Some(Err(e)) => panic!(e),
+            Some(Err(e)) => panic!("Iteration failed on known buffer. Got {}", e),
             Some(Ok(buf)) => buf,
         };
         // And the second returns leftover payload
@@ -178,7 +178,7 @@ mod chunk_iterator_tests {
         // When I call iterator.next() three times
         let res = match chunk_iter.next() {
             None => panic!("iterator returned no data first time"),
-            Some(Err(e)) => panic!(e),
+            Some(Err(e)) => panic!("Iteration failed on known buffer. Got {}", e),
             Some(Ok(i)) => i,
         };
         // Then the first two yield Some payload
@@ -192,7 +192,7 @@ mod chunk_iterator_tests {
         );
         let res2 = match chunk_iter.next() {
             None => panic!("iterator returned no data"),
-            Some(Err(e)) => panic!(e),
+            Some(Err(e)) => panic!("Iteration failed on known buffer. Got {}", e),
             Some(Ok(buf)) => buf,
         };
         assert_eq!(
@@ -220,7 +220,7 @@ mod chunk_iterator_tests {
         // When I call iterator.next() three times
         let res = match chunk_iter.next() {
             None => panic!("iterator returned no data first time"),
-            Some(Err(e)) => panic!(e),
+            Some(Err(e)) => panic!("Iteration failed on known buffer. Got {}", e),
             Some(Ok(buf)) => buf,
         };
         // Then the first yields Some payload
@@ -234,7 +234,7 @@ mod chunk_iterator_tests {
         );
         let res2 = match chunk_iter.next() {
             None => panic!("iterator returned no data"),
-            Some(Err(e)) => panic!(e),
+            Some(Err(e)) => panic!("Iteration failed on known buffer. Got {}", e),
             Some(Ok(buf)) => buf,
         };
         // And the second returns the leftover payload

--- a/src/chunk_iterator.rs
+++ b/src/chunk_iterator.rs
@@ -1,6 +1,8 @@
 use std::io;
 use std::io::{BufRead, Read};
 
+use crate::parser::EncodedChunk;
+
 #[allow(dead_code)] // Temporary while no consumer of this API
 /// An iterator for reading `chunk_size` bytes off the given `reader`
 pub struct BufferedIterator<T>
@@ -84,10 +86,12 @@ where
         match self.reader.next() {
             None => None,
             Some(Ok(buf)) => {
-                let chunk_string = format!(
-                    "{:03}OF{:03}{}",
-                    self.current_chunk_id, self.chunk_total, buf
-                );
+                let chunk = EncodedChunk {
+                    id: self.current_chunk_id,
+                    total: self.chunk_total,
+                    payload: buf,
+                };
+                let chunk_string = format!("{}", chunk);
                 self.current_chunk_id += 1;
                 Some(Ok(chunk_string))
             }

--- a/src/chunk_iterator.rs
+++ b/src/chunk_iterator.rs
@@ -6,7 +6,7 @@ use crate::parser::EncodedChunk;
 /// An iterator for reading `chunk_size` bytes off the given `reader`
 pub struct BufferedIterator<T>
 where
-    T: Read,
+    T: BufRead,
 {
     reader: T,
     chunk_size: u64,
@@ -14,7 +14,7 @@ where
 
 impl<T> BufferedIterator<T>
 where
-    T: Read,
+    T: BufRead,
 {
     /// Get a new iterator ready to read `chunk_size` bytes from `reader`
     pub fn new(reader: T, chunk_size: u64) -> Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,22 +108,21 @@ fn encode(input_filename: &Path, output_folder: &Path) {
         chunk_total
     );
 
-    let mut chunk_id = 1;
-    for chunk in chunk_iter {
+    for c in chunk_iter {
+        let chunk = c.expect("Problem reading reader");
         // Encode some data into bits.
-        let code =
-            QrCode::new(chunk.unwrap().as_bytes()).expect("Error encoding chunk into QR code");
+        let code = QrCode::new(format!("{}", chunk).as_bytes())
+            .expect("Error encoding chunk into QR code");
 
         // Render the bits into an image.
         let image = code.render::<Luma<u8>>().build();
 
         // Save the image.
         image
-            .save(output_folder.join(format!("{:03}.png", chunk_id)))
+            .save(output_folder.join(format!("{:03}.png", chunk.id)))
             .expect("Error saving chunk's QR code file");
 
-        println!("Saving QR {:03}/{}", chunk_id, &chunk_total);
-        chunk_id += 1; // FIXME: Chunk ID & total are inside chunk_iter, moved
+        println!("Saving QR {:03}/{}", chunk.id, chunk.total);
     }
     println!(
         "Split file in {} QR chunks, in folder {:?}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ extern crate clap;
 extern crate image;
 extern crate qrcode;
 
+mod chunk_iterator;
 mod parser;
 mod payload_size;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -31,6 +31,12 @@ pub struct EncodedChunk {
     pub payload: String,
 }
 
+impl fmt::Display for EncodedChunk {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:03}OF{:03}{}", self.id, self.total, self.payload)
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 /// Things that can go wrong when restoring a chunked file
 pub enum RestoreError {

--- a/src/payload_size.rs
+++ b/src/payload_size.rs
@@ -20,8 +20,9 @@
 /// Size of a header in bytes
 /// Three digits twice (id / total) plus delimiter string "OF" e.g.
 /// 013OF078
-const HEADER_SIZE_BYTES: u64 = 8;
+pub const HEADER_SIZE_BYTES: u64 = 8;
 
+#[allow(dead_code)] // TODO No need for this func anymore?
 /// How many chunks of `chunk_size_bytes` to send for a given payload of `payload_size_bytes`
 /// Taking into account the overhead of HEADER_SIZE_BYTES per chunk
 pub fn number_chunks_overhead(payload_size_bytes: u64, chunk_size_bytes: u16) -> u64 {

--- a/src/payload_size.rs
+++ b/src/payload_size.rs
@@ -23,10 +23,11 @@
 pub const HEADER_SIZE_BYTES: u64 = 8;
 
 #[allow(dead_code)] // TODO No need for this func anymore?
-/// How many chunks of `chunk_size_bytes` to send for a given payload of `payload_size_bytes`
-/// Taking into account the overhead of HEADER_SIZE_BYTES per chunk
+/// How many chunks of `chunk_size_bytes` to send for a given payload
+/// of `payload_size_bytes` Taking into account the overhead of
+/// `HEADER_SIZE_BYTES` per chunk
 pub fn number_chunks_overhead(payload_size_bytes: u64, chunk_size_bytes: u16) -> u64 {
-    let chunk_payload_size_bytes: u64 = (chunk_size_bytes as u64) - HEADER_SIZE_BYTES;
+    let chunk_payload_size_bytes: u64 = (u64::from(chunk_size_bytes)) - HEADER_SIZE_BYTES;
     ((payload_size_bytes as f64) / (chunk_payload_size_bytes as f64)).ceil() as u64
 }
 

--- a/tests/end_to_end_test.rs
+++ b/tests/end_to_end_test.rs
@@ -240,8 +240,6 @@ fn missing_chunk_error() {
     temp.close().expect("Error deleting temporary folder");
 }
 
-// TODO trigger parser::RestoreError's other enum cases (TooManyChunks, ChunkDecodeError, TotalMismatch) as unittest
-
 #[test]
 // Scenario: Restoring with a duplicate chunk succeeds
 fn duplicate_chunk_skips() {


### PR DESCRIPTION
New (unused) iterators for simplifying encoding, 

BufferedIterator wraps the `read N bytes` issue fine (based on PR #1), and ChunkIterator supposed to return a full chunk string on `next()`. This works, but the `base64` is not integrated yet.

Unit Tests are RED on the ChunkIterator, due to comparing byte array to string.

Open question is how to integrate base64 conversion inside the process, when the [base64::EncoderWriter](https://docs.rs/base64/0.13.0/base64/write/struct.EncoderWriter.html) approach is a `Writer` trait, not a `Reader` trait, so I can't make a oneliner pipeline cleanly, it seems.